### PR TITLE
chore(deps): add zod; feat(courses): zod validation for POST/PATCH

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       pino-http:
         specifier: ^10.4.0
         version: 10.5.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -3675,6 +3678,9 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zustand@5.0.7:
     resolution: {integrity: sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==}
     engines: {node: '>=12.20.0'}
@@ -7116,6 +7122,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zod@3.25.76: {}
 
   zustand@5.0.7(@types/react@19.1.10)(immer@10.1.1)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1)):
     optionalDependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,8 @@
     "multer": "^2.0.2",
     "pdf-parse": "^1.1.1",
     "pino": "^9.5.0",
-    "pino-http": "^10.4.0"
+    "pino-http": "^10.4.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",


### PR DESCRIPTION
I'll add Zod validation to the existing courses routes, reusing the current file and patterns to avoid duplication. This requires:
- Adding the zod dependency to server/package.json.
- Updating server/src/routes/courses.ts to validate POST and PATCH bodies with Zod.
I will edit these two files now.
Implemented Zod validation for Courses routes
What I changed
- server/package.json
  - Added runtime dependency: zod.
- server/src/routes/courses.ts
  - Added Zod schemas and validation:
    - POST /api/courses: requires name (string, non-empty), optional code (string).
    - PATCH /api/courses/:courseId: optional name/code (strings).
  - On validation failure returns 400 with the same response style used by this route: { error: "<message>" }.
  - Preserved all existing logic, patterns, and response shapes.
