### PR TITLE
fix(build): pass Navbar user prop; TS bundler resolution + node types…

### DIFF
--- a/.storybook/types.d.ts
+++ b/.storybook/types.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -46,18 +46,14 @@ const ChatWidget = () => {
 };
 
 export const AppShell = () => {
-  // אם קיים hook: const user = useAuth(state => state.user);
-  return (
-    // Using bg-background defined in tailwind.config.js
-    <div className="min-h-screen bg-background">
-      {/* הוספת הפרופס החסר כדי להתאים ל-NavigationProps */}
-      <Navbar user={null} />
-      {/* אם יש לך user אמיתי: <Navbar user={user} /> */}
+  const user = useAuth(state => state.user);
 
-      {/* Main Content Area */}
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar user={user} />
+
       <main className="py-8">
         <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
-          {/* The content of each page will be rendered here */}
           <Outlet />
         </div>
       </main>

--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Send, Maximize2, Minus } from 'lucide-react';
 import { Navbar } from './Navbar';
-// אם יש לך hook של הזדהות (למשל useAuth) אפשר בעתיד להחליף את null במשתמש בפועל:
-// import { useAuth } from '@/hooks/useAuth';
+import { useAuth } from '@/hooks/useAuth';
 
 const ChatWidget = () => {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/app/layout/AppShell.tsx
+++ b/src/app/layout/AppShell.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Send, Maximize2, Minus } from 'lucide-react';
 import { Navbar } from './Navbar';
+// אם יש לך hook של הזדהות (למשל useAuth) אפשר בעתיד להחליף את null במשתמש בפועל:
+// import { useAuth } from '@/hooks/useAuth';
 
 const ChatWidget = () => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -12,9 +14,12 @@ const ChatWidget = () => {
 
   return (
     <div className={containerClasses}>
-      <header className="bg-primary text-white p-3 flex justify-between items-center rounded-t-lg cursor-pointer" onClick={() => !isExpanded && setIsExpanded(true)}>
+      <header
+        className="bg-primary text-white p-3 flex justify-between items-center rounded-t-lg cursor-pointer"
+        onClick={() => !isExpanded && setIsExpanded(true)}
+      >
         <h3 className="font-bold">StudyFlow Bot</h3>
-        <button 
+        <button
           onClick={(e) => { e.stopPropagation(); setIsExpanded(!isExpanded); }}
           className="hover:bg-primary-dark p-1 rounded-full"
         >
@@ -42,10 +47,13 @@ const ChatWidget = () => {
 };
 
 export const AppShell = () => {
+  // אם קיים hook: const user = useAuth(state => state.user);
   return (
     // Using bg-background defined in tailwind.config.js
     <div className="min-h-screen bg-background">
-      <Navbar />
+      {/* הוספת הפרופס החסר כדי להתאים ל-NavigationProps */}
+      <Navbar user={null} />
+      {/* אם יש לך user אמיתי: <Navbar user={user} /> */}
 
       {/* Main Content Area */}
       <main className="py-8">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,16 +4,17 @@
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "NodeNext",
+
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
     "skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "NodeNext",
+    /* נשמרים כמו אצלך */
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "jsx": "react-jsx",
 
     /* Linting */
     "strict": true,
@@ -22,9 +23,15 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+
+    /* alias ל-@ + בסיס */
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": ["src/*"]
+    },
+
+    /* types של Vite */
+    "types": ["vite/client"]
   },
-  "include": ["src", "src/vite-env.d.ts", "vite.config.ts"]
+  "include": ["src", "src/vite-env.d.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,7 +19,15 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    /* NEW: לזהות טיפוסים של Node בקבצי קונפיג */
+    "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "playwright.config.ts",
+    ".storybook/**/*",
+    "vitest.config.ts"
+  ]
 }


### PR DESCRIPTION
…; declare '*.css' for storybook

# PR Template — StudyFlow

## What changed
- 

## How to test locally
- Commands/steps:
  - `pnpm run backend:lint` (expect: green)
  - `pnpm run backend:test` (expect: green)
  - Optional smoke via Swagger `/docs` or curl (list specific endpoints and expected statuses: 201/200/400/409)

## Links
- Swagger: http://localhost:4000/docs
- Related docs: `docs/DoD.md`, `docs/api/openapi.yaml`
- Preview/Env (if exists): 

## Known issues / notes
- 

---

## Checklist (Feature-Lite)
- [ ] Lint green: `pnpm run backend:lint`
- [ ] Tests green: `pnpm run backend:test` (+ tests for 400/401/403/404/409 where relevant)
- [ ] OpenAPI updated (`docs/api/openapi.yaml`), `/docs` loads without errors; example request/response added
- [ ] Zod returns 400 with clear message for invalid input
- [ ] Structured logs: `info` on success; `warn/error` on failures; no secrets in logs
- [ ] UI (if relevant): consistent Loading/Error/Success (RTL/Hebrew OK)
- [ ] Manual smoke: one success (201/200) + one intended failure (400) pass
- [ ] PR description includes How to test + link to `/docs`; CI green
