### PR TITLE
build: ensure server builds before app; add @vercel/node types; prism…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "pnpm -C server build && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
@@ -69,6 +69,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@types/react-router-dom": "^5.3.3",
+    "@vercel/node": "^3.2.0",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/browser": "3.2.4",
     "@vitest/coverage-v8": "3.2.4",

--- a/server/package.json
+++ b/server/package.json
@@ -7,8 +7,10 @@
     "dev": "cross-env NODE_ENV=development tsx watch src/local.ts",
     "start": "cross-env NODE_ENV=production node dist/local.js",
     "build": "tsc -p tsconfig.json",
-    "docs:sync-openapi": "npx -y @redocly/cli@latest bundle ../docs/api/openapi.yaml -o ../docs/api/openapi.json --ext json"
+    "docs:sync-openapi": "npx -y @redocly/cli@latest bundle ../docs/api/openapi.yaml -o ../docs/api/openapi.json --ext json",
+    "postinstall": "prisma generate --schema=server/prisma/schema.prisma"
   },
+  "prisma": { "schema": "server/prisma/schema.prisma" },
   "dependencies": {
     "@prisma/client": "^6.15.0",
     "dotenv": "^16.4.5",
@@ -18,12 +20,14 @@
     "pdf-parse": "^1.1.1",
     "pino": "^9.5.0",
     "pino-http": "^10.4.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/multer": "^2.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.14.12",
     "@types/pdf-parse": "^1.1.5",
     "@types/supertest": "^6.0.3",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,16 +2,15 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "CommonJS",
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
     "lib": ["ES2022"],
+    "types": ["node", "express"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "types": ["node", "express"]
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
…a postinstall+schema; express+node types

# PR Template — StudyFlow

## What changed
- 

## How to test locally
- Commands/steps:
  - `pnpm run backend:lint` (expect: green)
  - `pnpm run backend:test` (expect: green)
  - Optional smoke via Swagger `/docs` or curl (list specific endpoints and expected statuses: 201/200/400/409)

## Links
- Swagger: http://localhost:4000/docs
- Related docs: `docs/DoD.md`, `docs/api/openapi.yaml`
- Preview/Env (if exists): 

## Known issues / notes
- 

---

## Checklist (Feature-Lite)
- [ ] Lint green: `pnpm run backend:lint`
- [ ] Tests green: `pnpm run backend:test` (+ tests for 400/401/403/404/409 where relevant)
- [ ] OpenAPI updated (`docs/api/openapi.yaml`), `/docs` loads without errors; example request/response added
- [ ] Zod returns 400 with clear message for invalid input
- [ ] Structured logs: `info` on success; `warn/error` on failures; no secrets in logs
- [ ] UI (if relevant): consistent Loading/Error/Success (RTL/Hebrew OK)
- [ ] Manual smoke: one success (201/200) + one intended failure (400) pass
- [ ] PR description includes How to test + link to `/docs`; CI green
